### PR TITLE
Replace django.utils.six import for Django 3.0 compatibility

### DIFF
--- a/jsonfield_compat/compat.py
+++ b/jsonfield_compat/compat.py
@@ -1,4 +1,5 @@
 import json
+import six
 from functools import partial
 
 try:
@@ -9,7 +10,6 @@ except ImportError:  # pragma: no cover
     NativeJSONField = object
 
 from django.conf import settings
-from django.utils import six
 from django.utils.module_loading import import_string
 from psycopg2.extras import Json
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-django-jsonfield==1.0.1
+django-jsonfield==1.4.0
 psycopg2>=2.5.4
+six==1.13.0


### PR DESCRIPTION
`django-jsonfield` now supports Django 3.0, so this removes the deprecated `django.utils.six` import and replaces it with the `six` library. I can also update the test configuration to verify, but since it doesn't currently include Django 2 I left it alone